### PR TITLE
feat: replace consent string v1 with v2

### DIFF
--- a/src/yieldprobe/src/main/java/com/yieldlab/yieldprobe/helper/ConsentHelper.kt
+++ b/src/yieldprobe/src/main/java/com/yieldlab/yieldprobe/helper/ConsentHelper.kt
@@ -5,23 +5,23 @@ import android.preference.PreferenceManager
 
 /**
  * Read out the Consent string.
- * The class uses the proposed identifiers: "IABConsent_CMPPresent" and "IABConsent_ConsentString"
+ * The class uses the proposed identifiers: "IABTCF_CmpSdkID" and "IABTCF_TCString"
  */
 class ConsentHelper {
 
     /**
      * Read out the consent string.
-     * Taken form here: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Mobile%20In-App%20Consent%20APIs%20v1.0%20Final.md#mobile-in-app-cmp-api-v10-
+     * Taken form here: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#in-app-details
      * @param context pass a context
      * @return Consent string
      */
     fun getString(context: Context): String? {
 
         val mPreferences = PreferenceManager.getDefaultSharedPreferences(context)
-        val consentString = mPreferences.getString("IABConsent_ConsentString", "")
-        val cmpPresent = mPreferences.getBoolean("IABConsent_CMPPresent", false)
+        val consentString = mPreferences.getString("IABTCF_TCString", "")
+        val cmpPresent = mPreferences.getInt("IABTCF_CmpSdkID", 0)
 
-        if (cmpPresent) {
+        if (cmpPresent > 0) {
             return consentString
         } else {
             return null


### PR DESCRIPTION
It seems like the Yieldprobe SDK does not currently support the TC String in its latest version (v2). Here is a proposed solution to replace the current retrieval of the v1 string with the updated v2 string.

Looking forward to your thoughts!