### PR TITLE
fix: remove unnecessary CMP ID check

### DIFF
--- a/src/yieldprobe/src/main/java/com/yieldlab/yieldprobe/helper/ConsentHelper.kt
+++ b/src/yieldprobe/src/main/java/com/yieldlab/yieldprobe/helper/ConsentHelper.kt
@@ -5,7 +5,7 @@ import android.preference.PreferenceManager
 
 /**
  * Read out the Consent string.
- * The class uses the proposed identifiers: "IABTCF_CmpSdkID" and "IABTCF_TCString"
+ * The class uses the proposed identifier: "IABTCF_TCString"
  */
 class ConsentHelper {
 
@@ -16,15 +16,7 @@ class ConsentHelper {
      * @return Consent string
      */
     fun getString(context: Context): String? {
-
         val mPreferences = PreferenceManager.getDefaultSharedPreferences(context)
-        val consentString = mPreferences.getString("IABTCF_TCString", "")
-        val cmpPresent = mPreferences.getInt("IABTCF_CmpSdkID", 0)
-
-        if (cmpPresent > 0) {
-            return consentString
-        } else {
-            return null
-        }
+        return mPreferences.getString("IABTCF_TCString", null)
     }
 }


### PR DESCRIPTION
In the latest update there is a bug with some CMPs setting their ID as either `long` or `int` type. This leads to an exception being thrown when a `long` is encountered while retrieving the value.

IMO it should not be necessary to check this additional value in the first place and I would propose to remove the check completely.

What do you think?